### PR TITLE
chore: make readme example config be js

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ test('snapshot difference between 2 objects', () => {
 
 ...or add it globally to your jest config:
 
-```javascript
+```js
 // jest.config.js
 module.exports = {
   snapshotSerializers: [

--- a/README.md
+++ b/README.md
@@ -104,14 +104,13 @@ test('snapshot difference between 2 objects', () => {
 
 ...or add it globally to your jest config:
 
-```json
-{
-  "jest": {
-    "snapshotSerializers": [
-      "<rootDir>/node_modules/snapshot-diff/serializer.js"
-    ]
-  }
-}
+```javascript
+// jest.config.js
+module.exports = {
+  snapshotSerializers: [
+    require.resolve('snapshot-diff/serializer.js'),
+  ],
+};
 ```
 
 ## API


### PR DESCRIPTION
Relying less on string replacing `rootDir` is always a good thing, as that path is not necessarily true, especially in monorepos