### PR TITLE
feat: Simpler integration with the new setupFilesAfterEnv jest feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ test('snapshot difference between 2 React components state', () => {
 });
 ```
 
+... alternatively import it once, for instance in your [tests setup file](https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array):
+
+```js
+require('snapshot-diff/extend-expect');
+```
+
 Produced snapshot:
 
 ```diff

--- a/extend-expect.js
+++ b/extend-expect.js
@@ -1,0 +1,3 @@
+const { toMatchDiffSnapshot } = require('./build/');
+
+expect.extend({ toMatchDiffSnapshot });


### PR DESCRIPTION
Off the back of what @kentcdodds is doing over at https://github.com/testing-library/jest-dom and its simple:

```js
// jest.config.js

module.exports = {
   setupFilesAfterEnv: [
       require.resolve('jest-dom/extend-expect'),
   ],
}
```

I aim to introduce something similar to that, that would alleviate the need for a jest setup file.

Which will allow:
```js
// jest.config.js

module.exports = {
   setupFilesAfterEnv: [
       require.resolve('snapshot-diff/extend-expect'),
   ],
}
```

Or this at the top of the spec file:
```js
import 'snapshot-diff/extend-expect';
```