### PR TITLE
fix(breaking): update TS type to match latest @types/jest

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ type DiffOptions = {
 }
 
 declare namespace jest {
-  interface Matchers<R> {
+  interface Matchers<R, T> {
     /**
      * Compare the difference between the actual in the `expect()`
      * vs the object inside `valueB` with some extra options.


### PR DESCRIPTION
Hi,

the `Matchers` type of definitelytyped's jest package have been updated: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jest/index.d.ts#L667

This causes a compilation error since the interfaces don't match any more, e.g.

```
node_modules/snapshot-diff/index.d.ts:13:13 - error TS2428: All declarations of 'Matchers' must have identical type parameters.

13   interface Matchers<R> {
               ~~~~~~~~
```

There are several other similar examples e.g.
https://github.com/styled-components/jest-styled-components/pull/270
https://github.com/testing-library/jest-dom/pull/150