### PR TITLE
fix: update Matchers type value.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ type DiffOptions = {
 }
 
 declare namespace jest {
-  interface Matchers<R> {
+  interface Matchers<R, T> {
     /**
      * Compare the difference between the actual in the `expect()`
      * vs the object inside `valueB` with some extra options.


### PR DESCRIPTION
I fixed this one line in `index.d.ts`

```diff
declare namespace jest {
-  interface Matchers<R> {
+  interface Matchers<R, T> {
```

Without this fix, loading both `@types/jest/index.d.ts` and `snapshot-diff/index.d.ts` will result in the following error:

```
ERROR in
/path/to/project/node_modules/@types/jest/index.d.ts(667,15):
TS2428: All declarations of 'Matchers' must have identical type parameters.
ERROR in
/path/to/project/node_modules/snapshot-diff/index.d.ts(13,13):
TS2428: All declarations of 'Matchers' must have identical type parameters.
```

Reference: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39243