### PR TITLE
Update serializer types to support enzyme-to-json

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,8 +25,8 @@ declare namespace jest {
 
 interface Serializer {
   test: (value: any) => boolean;
-  print: (value: any, _serializer?: Function) => string;
-  diffOptions: (valueA: any, valueB: any) => DiffOptions;
+  print: (value: any, _serializer?: any) => any;
+  diffOptions?: (valueA: any, valueB: any) => DiffOptions;
 }
 
 declare module 'snapshot-diff' {


### PR DESCRIPTION
Current type declaration for serializer causes errors when used with
`enzyme-to-json`. Changes:
 * `diffOptions` is now an optional parameter (as it is in code).
 * Type declaration for the second `serialize` parameter of the `print`
   function has been weakened to `any` due to incorrect type used in
   `enzyme-to-json` (should be function, but has been typed serializer)
 * Return type declaration from `print` function has been weakened to
   `any`; this function is not limited to only returning strings.

Conflicting `enzyme-to-json` declaration:
https://github.com/adriantoine/enzyme-to-json/blob/d1f86ee82ce014bb3d63f521a5d553307948eff0/index.d.ts#L22-L25

Mismatch of `enzyme-to-json` `serializer` type in `print` function:
https://github.com/adriantoine/enzyme-to-json/blob/d1f86ee82ce014bb3d63f521a5d553307948eff0/src/createSerializer.js#L9-L11

Fixes #108

/cc: @simonsmith @thymikee