### PR TITLE
feat(breaking): Output jest mock function names in snapshot diff

### DIFF
--- a/__tests__/__snapshots__/snapshotDiff.test.js.snap
+++ b/__tests__/__snapshots__/snapshotDiff.test.js.snap
@@ -50,8 +50,8 @@ exports[`can use contextLines on diff 1`] = `
 
 exports[`can use contextLines with React components 1`] = `
 "Snapshot Diff:
-- <Component test=\\"say\\" />
-+ <Component test=\\"my name\\" />
+- <Component namedJestMock={[MockFunction test-mock-name]} test=\\"say\\" unnamedFunction={[Function unnamedFunction]} unnamedJestMock={[MockFunction]} />
++ <Component namedJestMock={[MockFunction test-mock-name]} test=\\"my name\\" unnamedFunction={[Function unnamedFunction]} unnamedJestMock={[MockFunction]} />
 
 @@ -10,1 +10,1 @@
 -     say
@@ -115,12 +115,12 @@ exports[`collapses diffs and strips ansi by default 1`] = `
 
 exports[`detects React components 1`] = `
 "Snapshot Diff:
-- <Component test=\\"say\\" />
-+ <Component test=\\"my name\\" />
+- <Component namedJestMock={[MockFunction test-mock-name]} test=\\"say\\" unnamedFunction={[Function unnamedFunction]} unnamedJestMock={[MockFunction]} />
++ <Component namedJestMock={[MockFunction test-mock-name]} test=\\"my name\\" unnamedFunction={[Function unnamedFunction]} unnamedJestMock={[MockFunction]} />
 
 @@ -5,14 +5,14 @@
     <span
-      onBlur={[Function onBlur]}
+      onBlur={[Function unnamedFunction]}
       onClick={[MockFunction]}
       onFocus={[MockFunction test-mock-name]}
     >

--- a/__tests__/__snapshots__/snapshotDiff.test.js.snap
+++ b/__tests__/__snapshots__/snapshotDiff.test.js.snap
@@ -53,13 +53,13 @@ exports[`can use contextLines with React components 1`] = `
 - <Component test=\\"say\\" />
 + <Component test=\\"my name\\" />
 
-@@ -6,1 +6,1 @@
+@@ -10,1 +10,1 @@
 -     say
 +     my name
-@@ -9,1 +9,1 @@
+@@ -13,1 +13,1 @@
 -     say
 +     my name
-@@ -32,1 +32,1 @@
+@@ -36,1 +36,1 @@
 -     say
 +     my name"
 `;
@@ -118,12 +118,12 @@ exports[`detects React components 1`] = `
 - <Component test=\\"say\\" />
 + <Component test=\\"my name\\" />
 
-@@ -1,14 +1,14 @@
-  <div>
-    <span />
-    <span />
-    <span />
-    <span>
+@@ -5,14 +5,14 @@
+    <span
+      onBlur={[Function onBlur]}
+      onClick={[MockFunction]}
+      onFocus={[MockFunction test-mock-name]}
+    >
 -     say
 +     my name
     </span>
@@ -135,7 +135,7 @@ exports[`detects React components 1`] = `
     <span />
     <span />
     <span />
-@@ -27,11 +27,11 @@
+@@ -31,11 +31,11 @@
     <span />
     <span />
     <span />

--- a/__tests__/__snapshots__/snapshotDiff.test.js.snap
+++ b/__tests__/__snapshots__/snapshotDiff.test.js.snap
@@ -165,3 +165,21 @@ exports[`failed optional deps throws with sensible message on missing react-test
 "Failed to load optional module \\"react-test-renderer\\". If you need to compare React elements, please add \\"react-test-renderer\\" to your project's dependencies.
 Cannot find module 'non-existent-module-for-testing' from 'snapshotDiff.test.js'"
 `;
+
+exports[`shows diff when comparing React fragments of varying length 1`] = `
+"Snapshot Diff:
+- <FragmentComponent />
++ <FragmentComponent withSecond={true} />
+
+- <div>
+-   First
+- </div>
++ Array [
++   <div>
++     First
++   </div>,
++   <div>
++     Second
++   </div>,
++ ]"
+`;

--- a/__tests__/snapshotDiff.test.js
+++ b/__tests__/snapshotDiff.test.js
@@ -1,5 +1,7 @@
 // @flow
 
+/* eslint-disable react/no-multi-comp */
+
 const React = require('react');
 const snapshotDiff = require('../src/index');
 
@@ -165,6 +167,17 @@ class Component extends React.Component<Props> {
   }
 }
 
+class FragmentComponent extends React.Component<Props> {
+  render() {
+    return (
+      <>
+        <div>First</div>
+        {this.props.withSecond ? <div>Second</div> : null}
+      </>
+    );
+  }
+}
+
 test('collapses diffs and strips ansi by default', () => {
   expect(snapshotDiff(a, b)).toMatchSnapshot();
 });
@@ -202,6 +215,12 @@ test('can use contextLines with React components', () => {
     snapshotDiff(<Component test="say" />, <Component test="my name" />, {
       contextLines: 0,
     })
+  ).toMatchSnapshot();
+});
+
+test('shows diff when comparing React fragments of varying length', () => {
+  expect(
+    snapshotDiff(<FragmentComponent />, <FragmentComponent withSecond />)
   ).toMatchSnapshot();
 });
 

--- a/__tests__/snapshotDiff.test.js
+++ b/__tests__/snapshotDiff.test.js
@@ -90,9 +90,9 @@ class Component extends React.Component<Props> {
         <span />
         <span />
         <span
-          onBlur={() => {}}
-          onClick={jest.fn()}
-          onFocus={jest.fn().mockName('test-mock-name')}
+          onBlur={this.props.unnamedFunction}
+          onClick={this.props.unnamedJestMock}
+          onFocus={this.props.namedJestMock}
         >
           {this.props.test}
         </span>
@@ -178,6 +178,12 @@ class FragmentComponent extends React.Component<Props> {
   }
 }
 
+const props = {
+  unnamedFunction: () => {},
+  unnamedJestMock: jest.fn(),
+  namedJestMock: jest.fn().mockName('test-mock-name'),
+};
+
 test('collapses diffs and strips ansi by default', () => {
   expect(snapshotDiff(a, b)).toMatchSnapshot();
 });
@@ -206,15 +212,22 @@ test('diffs short strings', () => {
 
 test('detects React components', () => {
   expect(
-    snapshotDiff(<Component test="say" />, <Component test="my name" />)
+    snapshotDiff(
+      <Component {...props} test="say" />,
+      <Component {...props} test="my name" />
+    )
   ).toMatchSnapshot();
 });
 
 test('can use contextLines with React components', () => {
   expect(
-    snapshotDiff(<Component test="say" />, <Component test="my name" />, {
-      contextLines: 0,
-    })
+    snapshotDiff(
+      <Component {...props} test="say" />,
+      <Component {...props} test="my name" />,
+      {
+        contextLines: 0,
+      }
+    )
   ).toMatchSnapshot();
 });
 

--- a/__tests__/snapshotDiff.test.js
+++ b/__tests__/snapshotDiff.test.js
@@ -87,7 +87,13 @@ class Component extends React.Component<Props> {
         <span />
         <span />
         <span />
-        <span>{this.props.test}</span>
+        <span
+          onBlur={() => {}}
+          onClick={jest.fn()}
+          onFocus={jest.fn().mockName('test-mock-name')}
+        >
+          {this.props.test}
+        </span>
         <span>{this.props.test}</span>
         <span />
         <span />

--- a/src/react-serializer.js
+++ b/src/react-serializer.js
@@ -3,6 +3,9 @@
 'use strict';
 
 const prettyFormat = require('pretty-format');
+const snapshot = require('jest-snapshot');
+
+const serializers = snapshot.getSerializers();
 
 const { ReactElement } = prettyFormat.plugins;
 const reactElement = Symbol.for('react.element');
@@ -22,7 +25,8 @@ function getReactComponentSerializer() {
     }
     throw error;
   }
-  return value => renderer.create(value).toJSON();
+  return value =>
+    prettyFormat(renderer.create(value), { plugins: serializers });
 }
 
 const reactSerializer = {

--- a/src/react-serializer.js
+++ b/src/react-serializer.js
@@ -7,7 +7,6 @@ const snapshot = require('jest-snapshot');
 
 const serializers = snapshot.getSerializers();
 
-const { ReactElement } = prettyFormat.plugins;
 const reactElement = Symbol.for('react.element');
 
 function getReactComponentSerializer() {
@@ -36,7 +35,7 @@ const reactSerializer = {
     return reactComponentSerializer(value);
   },
   diffOptions: (valueA: any, valueB: any) => {
-    const prettyFormatOptions = { plugins: [ReactElement], min: true };
+    const prettyFormatOptions = { plugins: serializers, min: true };
     return {
       aAnnotation: prettyFormat(valueA, prettyFormatOptions),
       bAnnotation: prettyFormat(valueB, prettyFormatOptions),


### PR DESCRIPTION
Use same serializers as jest-snapshot when serializing React components
rendered by react-test-renderer.

With the React serializer updated to use `prettyFormat`, this now
supports diffing React fragments when comparing a single element to
multiple elements returned. Adding test to confirm output.

Fixes #106
Fixes #111