### PR TITLE
Use jest-diff options to turn off colors in diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "jest-diff": "^25.1.0",
     "jest-snapshot": "^25.1.0",
-    "pretty-format": "^25.1.0",
-    "strip-ansi": "^6.0.0"
+    "pretty-format": "^25.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.0",

--- a/src/index.js
+++ b/src/index.js
@@ -51,12 +51,6 @@ const snapshotDiff = (valueA: any, valueB: any, options?: Options): string => {
     difference = diffStrings(valueA, valueB, mergedOptions);
   }
 
-  if (!mergedOptions.colors) {
-    const stripAnsi = require('strip-ansi');
-
-    difference = stripAnsi(difference);
-  }
-
   if (mergedOptions.stablePatchmarks && !mergedOptions.expand) {
     difference = difference.replace(
       /^@@ -[0-9]+,[0-9]+ \+[0-9]+,[0-9]+ @@$/gm,
@@ -67,12 +61,22 @@ const snapshotDiff = (valueA: any, valueB: any, options?: Options): string => {
   return SNAPSHOT_TITLE + difference;
 };
 
+// https://github.com/facebook/jest/tree/d81464622dc8857ba995ed04e121af2b3e8e33bc/packages/jest-diff#example-of-options-for-no-colors
+const noDiffColors = {
+  aColor: identity,
+  bColor: identity,
+  changeColor: identity,
+  commonColor: identity,
+  patchColor: identity,
+};
+
 function diffStrings(valueA: any, valueB: any, options: Options) {
   return diff(valueA, valueB, {
     expand: options.expand,
     contextLines: options.contextLines,
     aAnnotation: options.aAnnotation,
     bAnnotation: options.bAnnotation,
+    ...(!options.colors ? noDiffColors : {})
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5833,13 +5833,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
-strip-ansi@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
-  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
-  dependencies:
-    ansi-regex "^5.0.0"
-
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"


### PR DESCRIPTION
Make use of the new jest-diff options which allow color output to be
controlled. Use of example in documentation to turn off all color
output. strip-ansi is now unnecessary and has been removed as a
dependency.

Fixes #113

Documentation example: https://github.com/facebook/jest/tree/d81464622dc8857ba995ed04e121af2b3e8e33bc/packages/jest-diff#example-of-options-for-no-colors