### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "watch": "babel -w src --out-dir build"
   },
   "repository": "https://github.com/thymikee/snapshot-diff",
+  "homepage": "https://github.com/jest-community/snapshot-diff#readme",
+  "bugs": {
+    "url": "https://github.com/jest-community/snapshot-diff/issues"
+  },
   "engines": {
     "node": ">=14"
   },


### PR DESCRIPTION
## Summary

- add the npm package homepage URL
- add the npm package issue tracker URL through the `bugs` field

## Why

The package already points to the project repository, but npm metadata does not currently expose direct homepage or issue tracker links. This makes the package metadata more complete without changing runtime behavior.

## Checks

- `node -e "const p=require('./package.json'); const expectedHomepage='https://github.com/jest-community/snapshot-diff#readme'; const expectedBugs='https://github.com/jest-community/snapshot-diff/issues'; if (p.homepage !== expectedHomepage) throw new Error('bad homepage'); if (!p.bugs || p.bugs.url !== expectedBugs) throw new Error('bad bugs url'); console.log(JSON.stringify({name:p.name,version:p.version,repository:p.repository,homepage:p.homepage,bugs:p.bugs}, null, 2));"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`
- `npx -y -p node@18 -p yarn@1.22.22 yarn lint`
- `npx -y -p node@18 -p yarn@1.22.22 yarn typecheck`
- `CI=true npx -y -p node@18 -p yarn@1.22.22 yarn test --runInBand`

